### PR TITLE
fix: align Jaccard threshold with simhash distance

### DIFF
--- a/pipeline/__main__.py
+++ b/pipeline/__main__.py
@@ -80,7 +80,10 @@ def cluster(
     dry_run: bool = typer.Option(False),
     log_level: str = typer.Option("INFO"),
     parallel: int = typer.Option(6),
-    threshold: int = typer.Option(8, help="Hamming distance threshold for simhash"),
+    threshold: int = typer.Option(
+        8,
+        help="Max Hamming distance on 64-bit simhash (mapped to Jaccard similarity)",
+    ),
 ):
     """Cluster near-duplicate articles via SimHash."""
     settings = _common_settings(out, since, max_items, dry_run, log_level, parallel)

--- a/pipeline/cluster.py
+++ b/pipeline/cluster.py
@@ -26,7 +26,11 @@ def cluster(threshold: int = 8, logger: logging.Logger | None = None) -> list[di
     unassigned = set(a["article_id"] for a in arts)
     clusters: list[list[str]] = []
     by_id = {a["article_id"]: a for a in arts}
-    jaccard_threshold = 1.0 / max(threshold, 1)
+    # Map a simhash Hamming distance threshold (0-64) to a Jaccard similarity cutoff.
+    # This preserves the intent of "distance <= threshold" where 0 means identical
+    # and 64 means totally different.
+    dist = max(0, min(threshold, 64))
+    jaccard_threshold = 1.0 - dist / 64.0
 
     while unassigned:
         seed = unassigned.pop()

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -56,7 +56,8 @@ def test_similar_texts_cluster_together(tmp_path):
         upsert_article(conn, a1)
         upsert_article(conn, a2)
         upsert_article(conn, a3)
-    clusters = do_cluster(threshold=10)
+    # A higher Hamming distance maps to a lower Jaccard cutoff; 40 allows ~37.5%% overlap
+    clusters = do_cluster(threshold=40)
     sizes = sorted(len(c["members"]) for c in clusters)
     assert sizes == [1, 2]
 


### PR DESCRIPTION
## Summary
- map `threshold` to equivalent Jaccard cutoff (1 - dist / 64)
- clarify CLI help around similarity threshold mapping
- adjust regression test for updated Jaccard cutoff

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7609d79d48326ae60b864c2a4dbc3